### PR TITLE
Add Validation Support for DeltaOneFeed and EmFeed (Task 2.1)

### DIFF
--- a/Helpers/FeedValidationUtils.cs
+++ b/Helpers/FeedValidationUtils.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Helpers
+{
+    public static class FeedValidationUtils
+    {
+        public static int DecimalPlaces(decimal number)
+        {
+            var str = number.ToString(CultureInfo.InvariantCulture);
+            var dot = str.IndexOf('.');
+
+            return dot < 0 ? 0 : str.Length - dot - 1;
+        }
+    }
+}

--- a/Models/DeltaOneFeed.cs
+++ b/Models/DeltaOneFeed.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Models
+{
+    public class DeltaOneFeed : TradeFeed
+    {
+        public string Isin { get; set; }
+        public DateTime MaturityDate { get; set; }
+    }
+}

--- a/Models/EmFeed.cs
+++ b/Models/EmFeed.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Models
+{
+    public class EmFeed : TradeFeed
+    {
+        public decimal Sedol { get; set; }
+        public decimal AssetValue { get; set; }
+    }
+}

--- a/Models/TradeFeed.cs
+++ b/Models/TradeFeed.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Models
+{
+    public class TradeFeed
+    {
+        public int StagingId { get; set; }
+        public string SourceTradeRef { get; set; }
+        public int CounterpartyId { get; set; }
+        public int PrincipalId { get; set; }
+        public DateTime ValuationDate { get; set; }
+        public decimal CurrentPrice { get; set; }
+        public int SourceAccountId { get; set; }
+    }
+}

--- a/Results/ValidateResult.cs
+++ b/Results/ValidateResult.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Results
+{
+    public class ValidateResult
+    {
+        public bool IsValid => Errors.Count == 0;
+        public List<string> Errors { get; set; } = new();
+    }
+}

--- a/Validators/DeltaOneFeedValidator.cs
+++ b/Validators/DeltaOneFeedValidator.cs
@@ -1,6 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿using FeedManagerApp.Helpers;
 using FeedManagerApp.Models;
 using FeedManagerApp.Results;
+using System.Text.RegularExpressions;
 
 namespace FeedManagerApp.Validators
 {
@@ -13,7 +14,7 @@ namespace FeedManagerApp.Validators
             if (feed.StagingId < 1 || feed.CounterpartyId < 1 || feed.PrincipalId < 1 || feed.SourceAccountId < 1)
                 result.Errors.Add(ErrorCode.InvalidId);
 
-            if (feed.CurrentPrice < 0 || DecimalPlaces(feed.CurrentPrice) > 2)
+            if (feed.CurrentPrice < 0 || FeedValidationUtils.DecimalPlaces(feed.CurrentPrice) > 2)
                 result.Errors.Add(ErrorCode.InvalidPrice);
 
             if (!Regex.IsMatch(feed.Isin ?? "", @"^[A-Z]{2}\d{10}$"))
@@ -23,14 +24,6 @@ namespace FeedManagerApp.Validators
                 result.Errors.Add(ErrorCode.InvalidMaturityDate);
 
             return result;
-        }
-
-        private int DecimalPlaces(decimal number)
-        {
-            var str = number.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            var dot = str.IndexOf('.');
-
-            return dot < 0 ? 0 : str.Length - dot - 1;
         }
     }
 }

--- a/Validators/DeltaOneFeedValidator.cs
+++ b/Validators/DeltaOneFeedValidator.cs
@@ -1,0 +1,36 @@
+﻿using System.Text.RegularExpressions;
+using FeedManagerApp.Models;
+using FeedManagerApp.Results;
+
+namespace FeedManagerApp.Validators
+{
+    public class DeltaOneFeedValidator : IFeedValidator<DeltaOneFeed>
+    {
+        public ValidateResult Validate(DeltaOneFeed feed)
+        {
+            var result = new ValidateResult();
+
+            if (feed.StagingId < 1 || feed.CounterpartyId < 1 || feed.PrincipalId < 1 || feed.SourceAccountId < 1)
+                result.Errors.Add(ErrorCode.InvalidId);
+
+            if (feed.CurrentPrice < 0 || DecimalPlaces(feed.CurrentPrice) > 2)
+                result.Errors.Add(ErrorCode.InvalidPrice);
+
+            if (!Regex.IsMatch(feed.Isin ?? "", @"^[A-Z]{2}\d{10}$"))
+                result.Errors.Add(ErrorCode.InvalidIsin);
+
+            if (feed.MaturityDate <= feed.ValuationDate)
+                result.Errors.Add(ErrorCode.InvalidMaturityDate);
+
+            return result;
+        }
+
+        private int DecimalPlaces(decimal number)
+        {
+            var str = number.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var dot = str.IndexOf('.');
+
+            return dot < 0 ? 0 : str.Length - dot - 1;
+        }
+    }
+}

--- a/Validators/EmFeedValidator.cs
+++ b/Validators/EmFeedValidator.cs
@@ -1,4 +1,5 @@
-﻿using FeedManagerApp.Models;
+﻿using FeedManagerApp.Helpers;
+using FeedManagerApp.Models;
 using FeedManagerApp.Results;
 
 namespace FeedManagerApp.Validators
@@ -12,7 +13,7 @@ namespace FeedManagerApp.Validators
             if (feed.StagingId < 1 || feed.CounterpartyId < 1 || feed.PrincipalId < 1 || feed.SourceAccountId < 1)
                 result.Errors.Add(ErrorCode.InvalidId);
 
-            if (feed.CurrentPrice < 0 || DecimalPlaces(feed.CurrentPrice) > 2)
+            if (feed.CurrentPrice < 0 || FeedValidationUtils.DecimalPlaces(feed.CurrentPrice) > 2)
                 result.Errors.Add(ErrorCode.InvalidPrice);
 
             if (feed.Sedol <= 0 || feed.Sedol >= 100)
@@ -22,14 +23,6 @@ namespace FeedManagerApp.Validators
                 result.Errors.Add(ErrorCode.InvalidAssetValue);
 
             return result;
-        }
-
-        private int DecimalPlaces(decimal number)
-        {
-            var str = number.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            var dot = str.IndexOf('.');
-
-            return dot < 0 ? 0 : str.Length - dot - 1;
         }
     }
 }

--- a/Validators/EmFeedValidator.cs
+++ b/Validators/EmFeedValidator.cs
@@ -1,0 +1,35 @@
+﻿using FeedManagerApp.Models;
+using FeedManagerApp.Results;
+
+namespace FeedManagerApp.Validators
+{
+    public class EmFeedValidator : IFeedValidator<EmFeed>
+    {
+        public ValidateResult Validate(EmFeed feed)
+        {
+            var result = new ValidateResult();
+
+            if (feed.StagingId < 1 || feed.CounterpartyId < 1 || feed.PrincipalId < 1 || feed.SourceAccountId < 1)
+                result.Errors.Add(ErrorCode.InvalidId);
+
+            if (feed.CurrentPrice < 0 || DecimalPlaces(feed.CurrentPrice) > 2)
+                result.Errors.Add(ErrorCode.InvalidPrice);
+
+            if (feed.Sedol <= 0 || feed.Sedol >= 100)
+                result.Errors.Add(ErrorCode.InvalidSedol);
+
+            if (feed.AssetValue <= 0 || feed.AssetValue >= feed.Sedol)
+                result.Errors.Add(ErrorCode.InvalidAssetValue);
+
+            return result;
+        }
+
+        private int DecimalPlaces(decimal number)
+        {
+            var str = number.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var dot = str.IndexOf('.');
+
+            return dot < 0 ? 0 : str.Length - dot - 1;
+        }
+    }
+}

--- a/Validators/ErrorCode.cs
+++ b/Validators/ErrorCode.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Validators
+{
+    public static class ErrorCode
+    {
+        public const string InvalidId = "ID fields must be >= 1";
+        public const string InvalidPrice = "CurrentPrice must be >= 0 and have max 2 decimal digits";
+        public const string InvalidIsin = "ISIN must start with 2 uppercase letters followed by 10 digits";
+        public const string InvalidMaturityDate = "MaturityDate must be after ValuationDate";
+        public const string InvalidSedol = "Sedol must be > 0 and < 100";
+        public const string InvalidAssetValue = "AssetValue must be > 0 and < Sedol";
+    }
+}

--- a/Validators/IFeedValidator.cs
+++ b/Validators/IFeedValidator.cs
@@ -1,0 +1,15 @@
+﻿using FeedManagerApp.Models;
+using FeedManagerApp.Results;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Validators
+{
+    public interface IFeedValidator<T> where T : TradeFeed
+    {
+        ValidateResult Validate(T feed);
+    }
+}


### PR DESCRIPTION
This PR implements feed validation logic for DeltaOneFeed and EmFeed using a shared interface and centralized error handling. This provides a clean, testable, and reusable validation mechanism.

Implemented Features:

TradeFeed base class and two specialized feed types (DeltaOneFeed, EmFeed)

IFeedValidator<T> generic interface

Feed-specific validators: DeltaOneFeedValidator, EmFeedValidator

Common validation rules:

IDs must be ≥ 1

Price must be ≥ 0 and have ≤ 2 decimal digits

Specific rules for:

DeltaOneFeed: ISIN format, MaturityDate > ValuationDate

EmFeed: Sedol between (0, 100), AssetValue < Sedol

ErrorCode class for maintainable error strings

ValidateResult class to collect and report errors