### PR TITLE
Add Import Logic with Matchers and In-Memory Repository for DeltaOne and Em Feeds (Task 2.2)

### DIFF
--- a/Imposters/Delta1FeedImporter.cs
+++ b/Imposters/Delta1FeedImporter.cs
@@ -1,0 +1,49 @@
+﻿using FeedManagerApp.Matchers;
+using FeedManagerApp.Models;
+using FeedManagerApp.Repositories;
+using FeedManagerApp.Validators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Imposters
+{
+    public class Delta1FeedImporter
+    {
+        private readonly IFeedValidator<DeltaOneFeed> _validator;
+        private readonly IFeedMatcher<DeltaOneFeed> _matcher;
+        private readonly IDatabaseRepository _repository;
+
+        public Delta1FeedImporter(
+            IFeedValidator<DeltaOneFeed> validator,
+            IFeedMatcher<DeltaOneFeed> matcher,
+            IDatabaseRepository repository)
+        {
+            _validator = validator;
+            _matcher = matcher;
+            _repository = repository;
+        }
+
+        public void Import(IEnumerable<DeltaOneFeed> feeds)
+        {
+            foreach (var feed in feeds)
+            {
+                var result = _validator.Validate(feed);
+
+                if (!result.IsValid)
+                {
+                    _repository.SaveErrors(feed.StagingId, result.Errors);
+                    continue;
+                }
+
+                var existingFeeds = _repository.LoadFeeds<DeltaOneFeed>();
+                bool isDuplicate = existingFeeds.Exists(existing => _matcher.Match(feed, existing));
+
+                if (!isDuplicate)
+                    _repository.SaveFeed(feed);
+            }
+        }
+    }
+}

--- a/Imposters/EmFeedImporter.cs
+++ b/Imposters/EmFeedImporter.cs
@@ -1,0 +1,49 @@
+﻿using FeedManagerApp.Matchers;
+using FeedManagerApp.Models;
+using FeedManagerApp.Repositories;
+using FeedManagerApp.Validators;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Imposters
+{
+    public class EmFeedImporter
+    {
+        private readonly IFeedValidator<EmFeed> _validator;
+        private readonly IFeedMatcher<EmFeed> _matcher;
+        private readonly IDatabaseRepository _repository;
+
+        public EmFeedImporter(
+            IFeedValidator<EmFeed> validator,
+            IFeedMatcher<EmFeed> matcher,
+            IDatabaseRepository repository)
+        {
+            _validator = validator;
+            _matcher = matcher;
+            _repository = repository;
+        }
+
+        public void Import(IEnumerable<EmFeed> feeds)
+        {
+            foreach (var feed in feeds)
+            {
+                var result = _validator.Validate(feed);
+
+                if (!result.IsValid)
+                {
+                    _repository.SaveErrors(feed.StagingId, result.Errors);
+                    continue;
+                }
+
+                var existingFeeds = _repository.LoadFeeds<EmFeed>();
+                bool isDuplicate = existingFeeds.Exists(existing => _matcher.Match(feed, existing));
+
+                if (!isDuplicate)
+                    _repository.SaveFeed(feed);
+            }
+        }
+    }
+}

--- a/Matchers/DeltaOneFeedMatcher.cs
+++ b/Matchers/DeltaOneFeedMatcher.cs
@@ -1,0 +1,18 @@
+﻿using FeedManagerApp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Matchers
+{
+    public class DeltaOneFeedMatcher : IFeedMatcher<DeltaOneFeed>
+    {
+        public bool Match(DeltaOneFeed current, DeltaOneFeed other)
+        {
+            return current.CounterpartyId == other.CounterpartyId &&
+                   current.PrincipalId == other.PrincipalId;
+        }
+    }
+}

--- a/Matchers/EmFeedMatcher.cs
+++ b/Matchers/EmFeedMatcher.cs
@@ -1,0 +1,20 @@
+﻿using FeedManagerApp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Matchers
+{
+    public class EmFeedMatcher : IFeedMatcher<EmFeed>
+    {
+        public bool Match(EmFeed current, EmFeed other)
+        {
+            if (current.SourceAccountId != 0 && other.SourceAccountId != 0)
+                return current.SourceAccountId == other.SourceAccountId;
+
+            return current.StagingId == other.StagingId;
+        }
+    }
+}

--- a/Matchers/IFeedMatcher.cs
+++ b/Matchers/IFeedMatcher.cs
@@ -1,0 +1,14 @@
+﻿using FeedManagerApp.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Matchers
+{
+    public interface IFeedMatcher<T> where T : TradeFeed
+    {
+        bool Match(T current, T other);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,2 +1,20 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+﻿using FeedManagerApp.Imposters;
+using FeedManagerApp.Matchers;
+using FeedManagerApp.Models;
+using FeedManagerApp.Repositories;
+using FeedManagerApp.Validators;
+
+var repo = new InMemoryDatabaseRepository();
+var deltaImporter = new Delta1FeedImporter(
+    new DeltaOneFeedValidator(), new DeltaOneFeedMatcher(), repo);
+
+deltaImporter.Import(new List<DeltaOneFeed>
+{
+    new DeltaOneFeed
+    {
+        StagingId = 1, CounterpartyId = 10, PrincipalId = 20,
+        SourceAccountId = 5, CurrentPrice = 100.50m,
+        Isin = "US1234567890", ValuationDate = DateTime.Today,
+        MaturityDate = DateTime.Today.AddDays(10)
+    }
+});

--- a/Repositories/IDatabaseRepository.cs
+++ b/Repositories/IDatabaseRepository.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Repositories
+{
+    public interface IDatabaseRepository
+    {
+        List<T> LoadFeeds<T>();
+        void SaveFeed<T>(T feed);
+        void SaveErrors(int feedStagingId, List<string> errors);
+    }
+}

--- a/Repositories/InMemoryDatabaseRepository.cs
+++ b/Repositories/InMemoryDatabaseRepository.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeedManagerApp.Repositories
+{
+    public class InMemoryDatabaseRepository : IDatabaseRepository
+    {
+        private readonly Dictionary<string, List<object>> _storage = new();
+        private readonly List<string> _errorLog = new();
+
+        public List<T> LoadFeeds<T>()
+        {
+            var key = typeof(T).Name;
+
+            return _storage.ContainsKey(key)
+                ? _storage[key].Cast<T>().ToList()
+                : new List<T>();
+        }
+
+        public void SaveFeed<T>(T feed)
+        {
+            var key = typeof(T).Name;
+
+            if (!_storage.ContainsKey(key))
+                _storage[key] = new List<object>();
+
+            _storage[key].Add(feed);
+        }
+
+        public void SaveErrors(int feedStagingId, List<string> errors)
+        {
+            foreach (var error in errors)
+                _errorLog.Add($"[FeedId {feedStagingId}] {error}");
+        }
+
+        public List<string> GetAllErrors() => _errorLog;
+    }
+}


### PR DESCRIPTION
This PR completes the feed import logic for both DeltaOneFeed and EmFeed using validation, in-memory storage, and duplication checks.

Changes:

Introduced IDatabaseRepository and InMemoryDatabaseRepository to simulate data storage

Defined IFeedMatcher<T> interface with two implementations:

DeltaOneFeedMatcher: matches by CounterpartyId + PrincipalId

EmFeedMatcher: matches by SourceAccountId or StagingId

Implemented Delta1FeedImporter and EmFeedImporter:

Validate feed using appropriate validator

Check for duplicates using matcher

Save to repository only if valid and not matched

Save validation errors otherwise